### PR TITLE
Gives user ability to submit a query without returning data, and to clear input fields after submit.

### DIFF
--- a/frontend/components/rightPanel/schemaChildren/Query.tsx
+++ b/frontend/components/rightPanel/schemaChildren/Query.tsx
@@ -7,7 +7,7 @@ const { dialog } = require('electron').remote;
 import 'codemirror/lib/codemirror.css'; // Styline
 import 'codemirror/mode/sql/sql'; // Language (Syntax Highlighting)
 import 'codemirror/theme/lesser-dark.css'; // Theme
-import CodeMirror from 'react-codemirror';
+import CodeMirror from '@skidding/react-codemirror';
 
 /************************************************************
  *********************** TYPESCRIPT: TYPES ***********************

--- a/frontend/components/rightPanel/schemaChildren/Query.tsx
+++ b/frontend/components/rightPanel/schemaChildren/Query.tsx
@@ -34,7 +34,7 @@ class Query extends Component<QueryProps, state> {
   }
 
   state: state = {
-    queryString: 'testString',
+    queryString: '',
     queryLabel: '',
     show: false,
     trackQuery: false


### PR DESCRIPTION
## Types of changes
- [x] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
The query panel now gives users the ability to choose if their query is tracked or untracked. This means that users can easily create tables, insert rows, delete rows, or perform any test queries without adding to the query history or cluttering up the query statistics with unwanted data.
The query panel will now also clear the label, input, and Codemirror fields after a valid query is sent via the submit button.
## Approach
This update introduces a checkbox input field next to the label input field, whose onChange handler updates a boolean in state. If true, the query will run in the back end twice (once to initiate, once to return EXPLAIN ANALYZE stats) and populate the corresponding data tables and graphs on the front end. If false, the query will simply run once through the back end.
This update also links the values of the input fields to state, allowing them to re-render with no input after the user has submitted a valid query.
This update also changes the Codemirror component from react-codemirror version 1 to the @skidding/react-codemirror dependency that was already included in the package.json, but wasn't being used previously.
## Learning
https://github.com/JedWatson/react-codemirror/issues/106
## Screenshot(s)
Previous Query panel without option:
![Screen Shot 2020-10-01 at 5 04 53 PM](https://user-images.githubusercontent.com/64710913/94875340-5b6cb600-0409-11eb-9fd9-c6f76e1e504b.png)
Updated Query panel with option:
![Screen Shot 2020-10-01 at 5 04 09 PM](https://user-images.githubusercontent.com/64710913/94875344-60ca0080-0409-11eb-807d-b3712cacda2a.png)
