### PR TITLE
Added a Dummy Data Modal Component (front-end functionality)

### DIFF
--- a/frontend/assets/stylesheets/css/components.css
+++ b/frontend/assets/stylesheets/css/components.css
@@ -133,8 +133,23 @@ input *:focus {
           justify-content: center;
 }
 
-.dummy-data-table th, tr {
-  padding: 1rem;
+.dummy-data-table {
+  border: 1px solid #444c50;
+}
+
+.dummy-data-table th, .dummy-data-table tr {
+  padding: 0.5rem;
+  border-bottom: 1px solid #444c50;
+}
+
+.dummy-table-row td {
+  padding: 0.5rem;
+  text-align: center;
+}
+
+#generate-dummy-data {
+  padding: 0.2rem;
+  margin: 0.5rem;
 }
 
 #label-option {

--- a/frontend/assets/stylesheets/css/components.css
+++ b/frontend/assets/stylesheets/css/components.css
@@ -97,6 +97,26 @@ input *:focus {
   outline: none;
 }
 
+.dummy-data-select {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: row;
+          flex-direction: row;
+  padding: 1rem;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+}
+
+#dummy-rows-input {
+  min-width: 10em;
+  margin-left: 1.5em;
+  margin-right: 1.5em;
+}
+
 #label-option {
   min-width: 60%;
 }

--- a/frontend/assets/stylesheets/css/components.css
+++ b/frontend/assets/stylesheets/css/components.css
@@ -117,6 +117,26 @@ input *:focus {
   margin-right: 1.5em;
 }
 
+.dummy-data-table-container {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: row;
+          flex-direction: row;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+}
+
+.dummy-data-table th, tr {
+  padding: 1rem;
+}
+
 #label-option {
   min-width: 60%;
 }

--- a/frontend/assets/stylesheets/css/style.css
+++ b/frontend/assets/stylesheets/css/style.css
@@ -103,6 +103,26 @@ input *:focus {
   outline: none;
 }
 
+.dummy-data-select {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: row;
+          flex-direction: row;
+  padding: 1rem;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+}
+
+#dummy-rows-input {
+  min-width: 10em;
+  margin-left: 1.5em;
+  margin-right: 1.5em;
+}
+
 #label-option {
   min-width: 60%;
 }

--- a/frontend/assets/stylesheets/css/style.css
+++ b/frontend/assets/stylesheets/css/style.css
@@ -139,8 +139,23 @@ input *:focus {
           justify-content: center;
 }
 
-.dummy-data-table th, tr {
-  padding: 1rem;
+.dummy-data-table {
+  border: 1px solid #444c50;
+}
+
+.dummy-data-table th, .dummy-data-table tr {
+  padding: 0.5rem;
+  border-bottom: 1px solid #444c50;
+}
+
+.dummy-table-row td {
+  padding: 0.5rem;
+  text-align: center;
+}
+
+#generate-dummy-data {
+  padding: 0.2rem;
+  margin: 0.5rem;
 }
 
 #label-option {

--- a/frontend/assets/stylesheets/css/style.css
+++ b/frontend/assets/stylesheets/css/style.css
@@ -123,6 +123,26 @@ input *:focus {
   margin-right: 1.5em;
 }
 
+.dummy-data-table-container {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: row;
+          flex-direction: row;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+}
+
+.dummy-data-table th, tr {
+  padding: 1rem;
+}
+
 #label-option {
   min-width: 60%;
 }

--- a/frontend/assets/stylesheets/scss/components.scss
+++ b/frontend/assets/stylesheets/scss/components.scss
@@ -114,6 +114,17 @@ input {
   margin-right: 1.5em;
 }
 
+.dummy-data-table-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+}
+
+.dummy-data-table th, tr {
+  padding: 1rem;
+}
+
 #label-option {
   min-width: 60%;
 }

--- a/frontend/assets/stylesheets/scss/components.scss
+++ b/frontend/assets/stylesheets/scss/components.scss
@@ -121,8 +121,24 @@ input {
   justify-content: center;
 }
 
-.dummy-data-table th, tr {
-  padding: 1rem;
+.dummy-data-table {
+  border: 1px solid $border-darkmode;
+  th, tr {
+    padding: 0.5rem;
+    border-bottom: 1px solid $border-darkmode;
+  }
+}
+
+.dummy-table-row {
+  td {
+    padding: 0.5rem;
+    text-align: center;
+  }
+}
+
+#generate-dummy-data {
+  padding: 0.2rem;
+  margin: 0.5rem;
 }
 
 #label-option {

--- a/frontend/assets/stylesheets/scss/components.scss
+++ b/frontend/assets/stylesheets/scss/components.scss
@@ -101,6 +101,19 @@ input {
   }
 }
 
+.dummy-data-select {
+  display: flex;
+  flex-direction: row;
+  padding: 1rem;
+  align-items: center;
+}
+
+#dummy-rows-input {
+  min-width: 10em;
+  margin-left: 1.5em;
+  margin-right: 1.5em;
+}
+
 #label-option {
   min-width: 60%;
 }

--- a/frontend/components/rightPanel/schemaChildren/DummyDataModal.tsx
+++ b/frontend/components/rightPanel/schemaChildren/DummyDataModal.tsx
@@ -14,6 +14,7 @@ type DummyDataModalProps = {
 };
 
 type state = {
+  //currentSchema will need to be moved to state once the modal is rendered by the correct parent component
   currentSchema: string,
   currentTable: string,
   tableNames: string[],
@@ -57,6 +58,9 @@ class DummyDataModal extends Component<DummyDataModalProps, state> {
     //if no number is entered
     if (!this.state.rowNumber) {
       dialog.showErrorBox('Please enter a number of rows.', '');
+    }
+    if (this.state.currentTable === 'select table') {
+      dialog.showErrorBox('Please select a table.', '');
     }
     //reset input fields and update nested object in state
     else {
@@ -125,7 +129,12 @@ class DummyDataModal extends Component<DummyDataModalProps, state> {
   }
 
   submitDummyData = (event: any) => {
-    console.log(this.state.dataInfo);
+    const dataObj = {
+      //schemaName will eventually come from props, not state
+      schemaName: this.state.currentSchema,
+      dummyData: this.state.dataInfo
+    }
+    console.log(dataObj);
   }
 
   render() {

--- a/frontend/components/rightPanel/schemaChildren/DummyDataModal.tsx
+++ b/frontend/components/rightPanel/schemaChildren/DummyDataModal.tsx
@@ -18,6 +18,7 @@ type state = {
   currentTable: string,
   tableNames: string[],
   dataInfo: {},
+  rowNumber: string
 }
 
 class DummyDataModal extends Component<DummyDataModalProps, state> {
@@ -26,36 +27,105 @@ class DummyDataModal extends Component<DummyDataModalProps, state> {
     super(props);
     this.dropDownList = this.dropDownList.bind(this);
     this.selectHandler = this.selectHandler.bind(this);
+    this.addToTable = this.addToTable.bind(this);
+    this.changeRowNumber = this.changeRowNumber.bind(this);
+    this.deleteRow = this.deleteRow.bind(this);
+    this.submitDummyData = this.submitDummyData.bind(this);
   }
   //hard coded in for testing purposes
   state: state = {
     currentSchema: 'testSchema',
     currentTable: 'select table',
-    tableNames: ['customers', 'locations', 'suppliers'],
-    dataInfo: {customers: 200, locations: 20}
+    tableNames: ['customers', 'locations', 'suppliers', 'all'],
+    dataInfo: {},
+    rowNumber: ''
   }
 
+  //handler to change the dropdown display to the selected table name
   selectHandler = (eventKey, e: React.SyntheticEvent<unknown>) => {
     this.setState({currentTable: eventKey});
   };
 
+  //function to generate the dropdown optiosn from the table names in state
   dropDownList = () => {
     return this.state.tableNames.map((tableName, index) => <Dropdown.Item key={index} className="queryItem" eventKey={tableName}>{tableName}</Dropdown.Item>)
   };
+
+  //submit listener to add table name and rows to the dataInfo object in state
+  addToTable = (event: any) => {
+    event.preventDefault();
+    //if no number is entered
+    if (!this.state.rowNumber) {
+      dialog.showErrorBox('Please enter a number of rows.', '');
+    }
+    //reset input fields and update nested object in state
+    else {
+      let table = this.state.currentTable;
+      let number = Number(this.state.rowNumber);
+        if (table !== 'all') {
+          this.setState(prevState => ({
+            ...prevState,
+            currentTable: 'select table',
+            rowNumber: '',
+            dataInfo: {
+              ...prevState.dataInfo,
+              [table]: number
+            }
+          }))
+        }
+        else {
+          const dataInfo = {};
+          this.state.tableNames.forEach(table => {
+            if (table !== 'all') {
+              dataInfo[table] = number;
+            }
+          })
+          this.setState(prevState => ({
+            ...prevState,
+            currentTable: 'select table',
+            rowNumber: '',
+            dataInfo
+          }))
+        }
+      }
+  }
+
+  //onclick listener to delete row from table
+  deleteRow = (event: any) => {
+    let name = event.target.id;
+    this.setState(prevState => ({
+      ...prevState,
+      dataInfo: {
+        ...prevState.dataInfo,
+        [name]: undefined
+      }
+    }))
+  }
+
+  //onchange listener to update the rowNumber string in state
+  changeRowNumber = (event: any) => {
+    this.setState({ rowNumber: event.target.value })
+  }
 
   createRow = () => {
     //once state updates on click, render the table row from the object
     const newRows: JSX.Element[] = [];
       for (let key in this.state.dataInfo) {
-        newRows.push(
-          <tr>
-            <td>{key}</td>
-            <td>{this.state.dataInfo[key]}</td>
-            <td><button>x</button></td>
-          </tr>
-        )
+        if (this.state.dataInfo[key]) {
+          newRows.push(
+            <tr className="dummy-table-row" key={key}>
+              <td>{key}</td>
+              <td>{this.state.dataInfo[key]}</td>
+              <td><button id={key} onClick={this.deleteRow}>x</button></td>
+            </tr>
+          )
+        }
       }
     return newRows;
+  }
+
+  submitDummyData = (event: any) => {
+    console.log(this.state.dataInfo);
   }
 
   render() {
@@ -77,9 +147,12 @@ class DummyDataModal extends Component<DummyDataModalProps, state> {
                 {this.dropDownList()};
               </Dropdown.Menu>
             </Dropdown>
-            <input id="dummy-rows-input" type="text" placeholder="number of rows...">
+            <input id="dummy-rows-input" type="text" placeholder="number of rows..."
+            value={this.state.rowNumber}
+            onChange={this.changeRowNumber}>
             </input>
-            <button id="dummy-rows-button">
+            <button id="dummy-rows-button"
+                    onClick={this.addToTable}>
               add to table
             </button>
           </div>
@@ -94,6 +167,9 @@ class DummyDataModal extends Component<DummyDataModalProps, state> {
                 {this.createRow()}
               </tbody>
             </table>
+          </div>
+          <div id="generate-dummy-data">
+            <button onClick={this.submitDummyData}>Generate Dummy Data</button>
           </div>
       </div>
     )

--- a/frontend/components/rightPanel/schemaChildren/DummyDataModal.tsx
+++ b/frontend/components/rightPanel/schemaChildren/DummyDataModal.tsx
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import DropdownButton from 'react-bootstrap/DropdownButton';
+import Dropdown from 'react-bootstrap/Dropdown';
 
 const { dialog } = require('electron').remote;
 const { ipcRenderer } = window.require('electron');
@@ -9,6 +11,7 @@ type DummyDataModalProps = {
     show: boolean;
     showModal: any;
     onClose: any;
+    schemaTables: string[];
 };
 
 type state = {
@@ -17,6 +20,7 @@ type state = {
 }
 
 class DummyDataModal extends Component<DummyDataModalProps, state> {
+
   constructor(props: DummyDataModalProps) {
     super(props);
   }
@@ -25,14 +29,26 @@ class DummyDataModal extends Component<DummyDataModalProps, state> {
     dataInfo : {}
   }
 
+  dropDownList = () => {
+    //returns list of table names from schema
+      //untested code:
+      return this.props.schemaTables.map((tableName, index) => <Dropdown.Item></Dropdown.Item>)
+  };
+
   render() {
+
     if (this.props.show === false) {
       return null;
     }
+
     return (
-      <div>
+      <div className="dummy-data-modal">
+        <h3>Generate Dummy Data</h3>
+        <p>select table</p>
 
       </div>
     )
   }
 }
+
+export default DummyDataModal;

--- a/frontend/components/rightPanel/schemaChildren/DummyDataModal.tsx
+++ b/frontend/components/rightPanel/schemaChildren/DummyDataModal.tsx
@@ -1,0 +1,38 @@
+import React, { Component } from 'react';
+
+const { dialog } = require('electron').remote;
+const { ipcRenderer } = window.require('electron');
+
+type ClickEvent = React.MouseEvent<HTMLElement>;
+
+type DummyDataModalProps = {
+    show: boolean;
+    showModal: any;
+    onClose: any;
+};
+
+type state = {
+  currentSchema: string,
+  dataInfo: object
+}
+
+class DummyDataModal extends Component<DummyDataModalProps, state> {
+  constructor(props: DummyDataModalProps) {
+    super(props);
+  }
+  state: state = {
+    currentSchema: '',
+    dataInfo : {}
+  }
+
+  render() {
+    if (this.props.show === false) {
+      return null;
+    }
+    return (
+      <div>
+
+      </div>
+    )
+  }
+}

--- a/frontend/components/rightPanel/schemaChildren/DummyDataModal.tsx
+++ b/frontend/components/rightPanel/schemaChildren/DummyDataModal.tsx
@@ -17,7 +17,7 @@ type state = {
   currentSchema: string,
   currentTable: string,
   tableNames: string[],
-  dataInfo: object
+  dataInfo: {},
 }
 
 class DummyDataModal extends Component<DummyDataModalProps, state> {
@@ -32,16 +32,31 @@ class DummyDataModal extends Component<DummyDataModalProps, state> {
     currentSchema: 'testSchema',
     currentTable: 'select table',
     tableNames: ['customers', 'locations', 'suppliers'],
-    dataInfo: {}
+    dataInfo: {customers: 200, locations: 20}
   }
 
   selectHandler = (eventKey, e: React.SyntheticEvent<unknown>) => {
-    this.setState({currentTable: eventKey });
+    this.setState({currentTable: eventKey});
   };
 
   dropDownList = () => {
     return this.state.tableNames.map((tableName, index) => <Dropdown.Item key={index} className="queryItem" eventKey={tableName}>{tableName}</Dropdown.Item>)
   };
+
+  createRow = () => {
+    //once state updates on click, render the table row from the object
+    const newRows: JSX.Element[] = [];
+      for (let key in this.state.dataInfo) {
+        newRows.push(
+          <tr>
+            <td>{key}</td>
+            <td>{this.state.dataInfo[key]}</td>
+            <td><button>x</button></td>
+          </tr>
+        )
+      }
+    return newRows;
+  }
 
   render() {
 
@@ -67,6 +82,18 @@ class DummyDataModal extends Component<DummyDataModalProps, state> {
             <button id="dummy-rows-button">
               add to table
             </button>
+          </div>
+          <div className="dummy-data-table-container">
+            <table className="dummy-data-table">
+              <tbody>
+                <tr className="top-row">
+                  <th>table</th>
+                  <th># of rows</th>
+                  <th>delete</th>
+                </tr>
+                {this.createRow()}
+              </tbody>
+            </table>
           </div>
       </div>
     )

--- a/frontend/components/rightPanel/schemaChildren/DummyDataModal.tsx
+++ b/frontend/components/rightPanel/schemaChildren/DummyDataModal.tsx
@@ -11,11 +11,12 @@ type DummyDataModalProps = {
     show: boolean;
     showModal: any;
     onClose: any;
-    schemaTables: string[];
 };
 
 type state = {
   currentSchema: string,
+  currentTable: string,
+  tableNames: string[],
   dataInfo: object
 }
 
@@ -23,16 +24,24 @@ class DummyDataModal extends Component<DummyDataModalProps, state> {
 
   constructor(props: DummyDataModalProps) {
     super(props);
+    this.dropDownList = this.dropDownList.bind(this);
+    this.handleSelect = this.handleSelect.bind(this);
   }
+  //hard coded in for testing purposes
   state: state = {
-    currentSchema: '',
-    dataInfo : {}
+    currentSchema: 'testSchema',
+    currentTable: 'select table',
+    tableNames: ['customers', 'locations', 'suppliers'],
+    dataInfo: {}
+  }
+
+  //not working properly
+  handleSelect = (event) => {
+    console.log(event)
   }
 
   dropDownList = () => {
-    //returns list of table names from schema
-      //untested code:
-      return this.props.schemaTables.map((tableName, index) => <Dropdown.Item></Dropdown.Item>)
+    return this.state.tableNames.map((tableName, index) => <Dropdown.Item key={index} className="queryItem" value={tableName}>{tableName}</Dropdown.Item>)
   };
 
   render() {
@@ -45,7 +54,14 @@ class DummyDataModal extends Component<DummyDataModalProps, state> {
       <div className="dummy-data-modal">
         <h3>Generate Dummy Data</h3>
         <p>select table</p>
-
+        <Dropdown onSelect={this.handleSelect}>
+          <Dropdown.Toggle>
+            {this.state.currentTable}
+          </Dropdown.Toggle>
+          <Dropdown.Menu>
+            {this.dropDownList()};
+          </Dropdown.Menu>
+        </Dropdown>
       </div>
     )
   }

--- a/frontend/components/rightPanel/schemaChildren/DummyDataModal.tsx
+++ b/frontend/components/rightPanel/schemaChildren/DummyDataModal.tsx
@@ -25,7 +25,7 @@ class DummyDataModal extends Component<DummyDataModalProps, state> {
   constructor(props: DummyDataModalProps) {
     super(props);
     this.dropDownList = this.dropDownList.bind(this);
-    this.handleSelect = this.handleSelect.bind(this);
+    this.selectHandler = this.selectHandler.bind(this);
   }
   //hard coded in for testing purposes
   state: state = {
@@ -35,13 +35,12 @@ class DummyDataModal extends Component<DummyDataModalProps, state> {
     dataInfo: {}
   }
 
-  //not working properly
-  handleSelect = (event) => {
-    console.log(event)
-  }
+  selectHandler = (eventKey, e: React.SyntheticEvent<unknown>) => {
+    this.setState({currentTable: eventKey });
+  };
 
   dropDownList = () => {
-    return this.state.tableNames.map((tableName, index) => <Dropdown.Item key={index} className="queryItem" value={tableName}>{tableName}</Dropdown.Item>)
+    return this.state.tableNames.map((tableName, index) => <Dropdown.Item key={index} className="queryItem" eventKey={tableName}>{tableName}</Dropdown.Item>)
   };
 
   render() {
@@ -53,15 +52,22 @@ class DummyDataModal extends Component<DummyDataModalProps, state> {
     return (
       <div className="dummy-data-modal">
         <h3>Generate Dummy Data</h3>
-        <p>select table</p>
-        <Dropdown onSelect={this.handleSelect}>
-          <Dropdown.Toggle>
-            {this.state.currentTable}
-          </Dropdown.Toggle>
-          <Dropdown.Menu>
-            {this.dropDownList()};
-          </Dropdown.Menu>
-        </Dropdown>
+        <p>Select table and number of rows:</p>
+          <div className="dummy-data-select">
+            <Dropdown onSelect={this.selectHandler}>
+              <Dropdown.Toggle>
+                {this.state.currentTable}
+              </Dropdown.Toggle>
+              <Dropdown.Menu>
+                {this.dropDownList()};
+              </Dropdown.Menu>
+            </Dropdown>
+            <input id="dummy-rows-input" type="text" placeholder="number of rows...">
+            </input>
+            <button id="dummy-rows-button">
+              add to table
+            </button>
+          </div>
       </div>
     )
   }

--- a/frontend/components/rightPanel/schemaChildren/Query.tsx
+++ b/frontend/components/rightPanel/schemaChildren/Query.tsx
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+//delete before pull request
+import DummyDataModal from './DummyDataModal';
 
 const { ipcRenderer } = window.require('electron');
 const { dialog } = require('electron').remote;
@@ -105,6 +107,9 @@ class Query extends Component<QueryProps, state> {
 
     return (
       <div id="query-panel">
+        <div id="delete-me">
+          <DummyDataModal show={true} showModal={true} onClose={null}/>
+        </div>
         <h3>Query</h3>
         <form onSubmit={this.handleQuerySubmit}>
           <div className="query-label">


### PR DESCRIPTION
## Types of changes
- [ ] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
A dummy data component (can be rendered as a modal) is now present in the front end. A user can design a dummy data request object (referencing existing tables and user-inputted amount of rows), see the info generated to a table, delete certain rows from that table, and submit the request. Currently, the 'submit' button simply logs the data object to the console, (awaiting back end functionality). 
## Approach
Created a new component that shapes a user request on the front end.
## Learning
Typescript React onSelect Events:
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/13079
## Screenshot(s)
Dummy Data Modal:
![Screen Shot 2020-10-03 at 2 33 29 PM](https://user-images.githubusercontent.com/64710913/95002121-811eca00-0585-11eb-9d15-23d39436cfad.png)
Once data has been added:
![Screen Shot 2020-10-03 at 2 33 44 PM](https://user-images.githubusercontent.com/64710913/95002123-85e37e00-0585-11eb-9b52-ba88470e1163.png)