### PR TITLE
completed de-dockerization

### DIFF
--- a/backend/main.ts
+++ b/backend/main.ts
@@ -26,7 +26,7 @@ const path = require('path');
 let mainWindow: any;
 
 //global variable to determine whether or not containers are still running
-let pruned: boolean = false;
+// let pruned: boolean = false;
 
 let mainMenu = Menu.buildFromTemplate(require('./mainMenu'));
 // Keep a reference for dev mode
@@ -80,44 +80,44 @@ function createWindow() {
     // uncomment code below before running production build and packaging
     // const yamlPath = join(__dirname, '../../docker-compose.yml')
     // const runDocker: string = `docker-compose -f '${yamlPath}' up -d`;
-    const runDocker: string = `docker-compose up -d`;
-    exec(runDocker, (error, stdout, stderr) => {
-      if (error) {
-        console.log(`error: ${error.message}`);
-        return;
-      }
-      if (stderr) {
-        console.log(`stderr: ${stderr}`);
-        return;
-      }
-      console.log(`${stdout}`);
-    })
+    // const runDocker: string = `docker-compose up -d`;
+    // exec(runDocker, (error, stdout, stderr) => {
+    //   if (error) {
+    //     console.log(`error: ${error.message}`);
+    //     return;
+    //   }
+    //   if (stderr) {
+    //     console.log(`stderr: ${stderr}`);
+    //     return;
+    //   }
+    //   console.log(`${stdout}`);
+    // })
   });
 }
 
 app.on('before-quit', (event: any) => {
   // check if containers have already been pruned--else, continue with default behavior to terminate application
-  if (!pruned) {
-    event.preventDefault();
-    // Stop and remove postgres-1 and busybox-1 Docker containers upon window exit.
-    const stopContainers: string = 'docker stop postgres-1 busybox-1';
-    const pruneContainers: string = 'docker rm -f postgres-1 busybox-1';
-    // this command removes the volume which stores the session data for the postgres instance
-    // comment this out for dev
-    const pruneVolumes: string = 'docker volume rm -f seeqr_database-data';
+  // if (!pruned) {
+  //   event.preventDefault();
+  //   // Stop and remove postgres-1 and busybox-1 Docker containers upon window exit.
+  //   const stopContainers: string = 'docker stop postgres-1 busybox-1';
+  //   const pruneContainers: string = 'docker rm -f postgres-1 busybox-1';
+  //   // this command removes the volume which stores the session data for the postgres instance
+  //   // comment this out for dev
+  //   const pruneVolumes: string = 'docker volume rm -f seeqr_database-data';
 
-    // use this string for production build
-    // const pruneVolumes: string = 'docker volume rm -f app_database-data'
+  //   // use this string for production build
+  //   // const pruneVolumes: string = 'docker volume rm -f app_database-data'
 
-    const step4 = () => {
-      pruned = true;
-      app.quit()
-    };
-    const step3 = () => execute(pruneVolumes, step4);
-    const step2 = () => execute(pruneContainers, step3);
+  //   const step4 = () => {
+  //     pruned = true;
+  //     app.quit()
+  //   };
+  //   const step3 = () => execute(pruneVolumes, step4);
+  //   const step2 = () => execute(pruneContainers, step3);
 
-    execute(stopContainers, step2);
-  }
+    execute('cd ../backend', app.quit);
+  // }
 })
 
 


### PR DESCRIPTION
So the issue wasn't actually with the Docker code -- that came out fine. The troublesome line is now main.ts 119. For whatever reason, if we don't invoke a function (any function) from channels.ts in one of main.ts's event emitters (any emmiter), the code in channels.ts will never get executed, ipcMain won't exist, and there will be nothing to listen to for the front end's messages. 

I'm still not sure why, but I left in the call to execute which comes from channels. I replaced the command from something Docker related to some nonsense, it still works. 

FWIW, I also tried exporting another function from channels (a test function I created and subsequently deleted) and executing it from main. That also worked.