### PR TITLE
create script to build from windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .DS_Store
 dvdrental.tar
 package-lock.json
+/appBuilds

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "tsc": "tsc",
     "start": "cross-env NODE_ENV=production electron --noDevServer .",
     "dev": "cross-env NODE_ENV=development webpack-dev-server --hot",
-    "test": "jest --verbose"
+    "test": "jest --verbose",
+    "win-build-apps": "sudo npx electron-packager . SeeQR --out=appBuilds --platform=win32 --platform=darwin"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Builds app for windows and macos, for 64 bit architecture. Depends on having "sudo" command installed and available in command-line