### PR TITLE
Feedback snackbar

### DIFF
--- a/frontend/components/App.tsx
+++ b/frontend/components/App.tsx
@@ -3,7 +3,12 @@ import styled from 'styled-components';
 import { MuiThemeProvider } from '@material-ui/core/';
 import { StylesProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { MuiTheme, bgColor, sidebarWidth, defaultMargin } from '../style-variables';
+import {
+  MuiTheme,
+  bgColor,
+  sidebarWidth,
+  defaultMargin,
+} from '../style-variables';
 import GlobalStyle from '../GlobalStyle';
 import { AppState, CreateNewQuery, QueryData } from '../types';
 import { createQuery, key } from '../lib/queries';
@@ -12,6 +17,7 @@ import QueryView from './views/QueryView/QueryView';
 import DbView from './views/DbView/DbView';
 import CompareView from './views/CompareView/CompareView';
 import QuickStartView from './views/QuickStartView';
+import FeedbackModal from './modal/FeedbackModal';
 
 const AppContainer = styled.div`
   display: grid;
@@ -110,6 +116,7 @@ const App = () => {
             />
             <QuickStartView show={shownView === 'quickStartView'} />
           </Main>
+          <FeedbackModal />
         </AppContainer>
       </MuiThemeProvider>
     </StylesProvider>

--- a/frontend/components/modal/FeedbackModal.tsx
+++ b/frontend/components/modal/FeedbackModal.tsx
@@ -1,0 +1,62 @@
+import React, { useState, useEffect } from 'react';
+import { IpcMainEvent } from 'electron';
+import { Snackbar } from '@material-ui/core';
+import MuiAlert, { AlertProps } from '@material-ui/lab/Alert';
+
+import { readingTime } from '../../lib/utils';
+
+const { ipcRenderer } = window.require('electron');
+
+type Severity = 'error' | 'success' | 'info' | 'warning';
+
+interface Feedback {
+  type: Severity;
+  message: string | Record<string, unknown>;
+}
+
+function Alert(props: AlertProps) {
+  return <MuiAlert elevation={6} variant="filled" {...props} />;
+}
+
+const FeedbackModal = () => {
+  const [isOpen, setOpen] = useState(false);
+  const [message, setMessage] = useState('');
+  const [severity, setSeverity] = useState<Severity>('info');
+
+  useEffect(() => {
+    // TODO: type guard
+    const receiveFeedback = (evt: IpcMainEvent, feedback: Feedback) => {
+      if (feedback.type === 'error') {
+        setSeverity(feedback.type);
+
+        if (typeof feedback.message === 'string') setMessage(feedback.message);
+        // TODO: custom messages depending on properties of message.
+        else
+          setMessage(feedback.message?.toString() ?? 'ERROR: Operation Failed');
+
+        setOpen(true);
+      }
+    };
+    ipcRenderer.on('feedback', receiveFeedback);
+    return () => ipcRenderer.removeListener('feedback', receiveFeedback);
+  });
+
+  const handleClose = () => setOpen(false);
+
+  return (
+    <Snackbar
+      open={isOpen}
+      onClose={handleClose}
+      autoHideDuration={readingTime(message)}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      // disable hiding on clickAway
+      ClickAwayListenerProps={{ onClickAway: () => {} }}
+    >
+      <Alert onClose={handleClose} severity={severity}>
+        {message}
+      </Alert>
+    </Snackbar>
+  );
+};
+
+export default FeedbackModal;

--- a/frontend/components/modal/FeedbackModal.tsx
+++ b/frontend/components/modal/FeedbackModal.tsx
@@ -4,15 +4,10 @@ import { Snackbar } from '@material-ui/core';
 import MuiAlert, { AlertProps } from '@material-ui/lab/Alert';
 
 import { readingTime } from '../../lib/utils';
+import type {Feedback, FeedbackSeverity} from '../../types'
 
 const { ipcRenderer } = window.require('electron');
 
-type Severity = 'error' | 'success' | 'info' | 'warning';
-
-interface Feedback {
-  type: Severity;
-  message: string | Record<string, unknown>;
-}
 
 function Alert(props: AlertProps) {
   return <MuiAlert elevation={6} variant="filled" {...props} />;
@@ -21,7 +16,7 @@ function Alert(props: AlertProps) {
 const FeedbackModal = () => {
   const [isOpen, setOpen] = useState(false);
   const [message, setMessage] = useState('');
-  const [severity, setSeverity] = useState<Severity>('info');
+  const [severity, setSeverity] = useState<FeedbackSeverity>('info');
 
   useEffect(() => {
     // TODO: type guard

--- a/frontend/components/modal/FeedbackModal.tsx
+++ b/frontend/components/modal/FeedbackModal.tsx
@@ -4,10 +4,9 @@ import { Snackbar } from '@material-ui/core';
 import MuiAlert, { AlertProps } from '@material-ui/lab/Alert';
 
 import { readingTime } from '../../lib/utils';
-import type {Feedback, FeedbackSeverity} from '../../types'
+import type { Feedback, FeedbackSeverity } from '../../types';
 
 const { ipcRenderer } = window.require('electron');
-
 
 function Alert(props: AlertProps) {
   return <MuiAlert elevation={6} variant="filled" {...props} />;
@@ -21,14 +20,11 @@ const FeedbackModal = () => {
   useEffect(() => {
     // TODO: type guard
     const receiveFeedback = (evt: IpcMainEvent, feedback: Feedback) => {
-      if (feedback.type === 'error') {
+      const validTypes: FeedbackSeverity[] = ['error', 'info', 'warning'];
+      // Ignore 'success' feedback.
+      if (validTypes.includes(feedback.type)) {
         setSeverity(feedback.type);
-
-        if (typeof feedback.message === 'string') setMessage(feedback.message);
-        // TODO: custom messages depending on properties of message.
-        else
-          setMessage(feedback.message?.toString() ?? 'ERROR: Operation Failed');
-
+        setMessage(feedback.message?.toString() ?? 'ERROR: Operation Failed');
         setOpen(true);
       }
     };

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,11 +1,22 @@
-
+import ms from 'ms'
 /**
  * Execute function at most once. Doesn't passthrough functions returned value
  */
-export const once = (func) => {
+export const once = (func: Function) => {
   let hasRun = false;
   return () => {
     if (!hasRun) func();
     hasRun = true;
   };
 };
+
+/**
+ * Get reading time for string in ms. Calculated based on number of words
+ * Minimum reading time is 3s 
+ */
+export const readingTime = (str: string) => {
+  const averageWordsPerMinute = 200;
+  const totalWords = str.split(' ').length
+  const readTime = totalWords * ms('1m') / averageWordsPerMinute
+  return Math.max(ms('3s'), readTime)
+}

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,4 +1,8 @@
 import ms from 'ms'
+import type {Feedback } from '../types'
+
+const { ipcRenderer } = window.require('electron');
+
 /**
  * Execute function at most once. Doesn't passthrough functions returned value
  */
@@ -20,3 +24,12 @@ export const readingTime = (str: string) => {
   const readTime = totalWords * ms('1m') / averageWordsPerMinute
   return Math.max(ms('3s'), readTime)
 }
+
+/**
+ * Emit feedback event that can be listened to by ipcRenderer.
+ * Used to send messages to FeedbackModal.tsx
+ */
+export const sendFeedback = (feedback: Feedback) => {
+  const rendererId = window.require('electron').remote.getCurrentWebContents().id;
+  ipcRenderer.sendTo(rendererId, 'feedback', feedback)
+} 

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -44,6 +44,13 @@ export interface QueryData {
 
 export type ValidTabs = 'Results' | 'Execution Plan';
 
+export type FeedbackSeverity = 'error' | 'success' | 'info' | 'warning';
+
+export interface Feedback {
+  type: FeedbackSeverity;
+  message: string | Record<string, unknown>;
+}
+
 // Electron Interface //
 
 // Due to legacy reasons data arriving from the backend is being treated as

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.57",
     "@skidding/react-codemirror": "^1.0.2",
     "@types/react-router-dom": "^5.1.5",
     "@types/styled-components": "^5.1.7",


### PR DESCRIPTION
Accept 'error', 'warning' and 'info' feedback events from backend and frontend.

To show feedback from frontend, use sendFeedback function from lib/utils.ts