### PR TITLE
Show Spinner for async-started and async-complete events from backend

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "es2021": true,
     "node": true
   },
-  "globals": { "JSX": "readonly" },
+  "globals": { "JSX": "readonly",  "Chart": "readonly" },
   "extends": [
     "plugin:react/recommended",
     "airbnb",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "es2021": true,
     "node": true
   },
-  "globals": { "JSX": "readonly",  "Chart": "readonly" },
+  "globals": { "JSX": "readonly", "Chart": "readonly", "NodeJS": "readonly" },
   "extends": [
     "plugin:react/recommended",
     "airbnb",

--- a/frontend/components/App.tsx
+++ b/frontend/components/App.tsx
@@ -18,6 +18,7 @@ import DbView from './views/DbView/DbView';
 import CompareView from './views/CompareView/CompareView';
 import QuickStartView from './views/QuickStartView';
 import FeedbackModal from './modal/FeedbackModal';
+import Spinner from './modal/Spinner'
 
 const AppContainer = styled.div`
   display: grid;
@@ -83,6 +84,7 @@ const App = () => {
     // Styled Components must be injected last in order to override Material UI style: https://material-ui.com/guides/interoperability/#controlling-priority-3
     <StylesProvider injectFirst>
       <MuiThemeProvider theme={MuiTheme}>
+        <Spinner />
         <AppContainer>
           <CssBaseline />
           <GlobalStyle />

--- a/frontend/components/modal/DuplicateDbModal.tsx
+++ b/frontend/components/modal/DuplicateDbModal.tsx
@@ -44,7 +44,7 @@ const DuplicateDbModal = ({
     const schemaNameInput = event.target.value;
     let dbSafeName = schemaNameInput.toLowerCase();
     dbSafeName = dbSafeName.replace(/[^A-Z0-9]/gi, '');
-    //check if the newSchemaName is
+    // check if the newSchemaName is
     setNewSchemaName(dbSafeName);
   };
 

--- a/frontend/components/modal/Spinner.tsx
+++ b/frontend/components/modal/Spinner.tsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from 'react';
+import { LinearProgress } from '@material-ui/core';
+import styled from 'styled-components';
+
+const { ipcRenderer } = window.require('electron');
+
+const StyledLinearProg = styled(LinearProgress)`
+  /* Material Ui Drawer component used by sidebar has z-index: 1200 */
+  z-index: 1300;
+  height: 2px;
+  visibility: ${({ show }: { show: boolean }) => (show ? 'visible' : 'hidden')};
+`;
+
+const Spinner = () => {
+  const [show, setShow] = useState(false);
+
+  const delay = 500
+  let delayTimer: NodeJS.Timeout
+
+  useEffect(() => {
+    const showProgress = () => {
+      // show spinner after delay ms
+      // using global to disambiguate for ts compiler: https://github.com/Microsoft/TypeScript/issues/30128
+      delayTimer = global.setTimeout(() => setShow(true), delay)
+    };
+    ipcRenderer.on('async-started', showProgress );
+    return () => ipcRenderer.removeListener('feedback', showProgress);
+  });
+
+  useEffect(() => {
+    const hideProgress = () => {
+      // kill currently delayed timer if any
+      clearTimeout(delayTimer)
+      setShow(false)
+    };
+    ipcRenderer.on('async-complete', hideProgress );
+    return () => ipcRenderer.removeListener('feedback', hideProgress);
+  });
+
+  return <StyledLinearProg show={show} />;
+};
+
+export default Spinner;

--- a/frontend/components/views/CompareView/CompareChart.tsx
+++ b/frontend/components/views/CompareView/CompareChart.tsx
@@ -1,7 +1,4 @@
 import React from 'react';
-// eslint complains about undefined Chart if not imported, ts complain Chart is
-// not used if imported. Pick your poison
-import type { Chart } from 'chart.js';
 import { Bar, defaults, ChartData } from 'react-chartjs-2';
 import { AppState } from '../../../types';
 import {keyFromData, getTotalTime} from '../../../lib/queries'


### PR DESCRIPTION
Spinner is delayed by 500 ms to prevent it from showing for very short functions. 