### PR TITLE
Prevent Saving of queries with missing information

### DIFF
--- a/frontend/components/App.tsx
+++ b/frontend/components/App.tsx
@@ -18,7 +18,7 @@ import DbView from './views/DbView/DbView';
 import CompareView from './views/CompareView/CompareView';
 import QuickStartView from './views/QuickStartView';
 import FeedbackModal from './modal/FeedbackModal';
-import Spinner from './modal/Spinner'
+import Spinner from './modal/Spinner';
 
 const AppContainer = styled.div`
   display: grid;
@@ -49,10 +49,13 @@ const App = () => {
    * Hook to create new Query from data
    */
   const createNewQuery: CreateNewQuery = (query: QueryData) => {
-    const newQueries = createQuery(queries, query);
-    setQueries(newQueries);
+    // Only save query to saved queries if it contains all minimum information
+    if (query.label && query.db && query.sqlString) {
+      const newQueries = createQuery(queries, query);
+      setQueries(newQueries);
+    }
     // we must set working query to newly created query otherwise query view won't update
-    setWorkingQuery(newQueries[key(query)]);
+    setWorkingQuery(query);
   };
 
   // determine which view should be visible depending on selected view and

--- a/frontend/components/views/QueryView/QueryLabel.tsx
+++ b/frontend/components/views/QueryView/QueryLabel.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { TextField, Box} from '@material-ui/core/';
+import { TextField, Box } from '@material-ui/core/';
 // import styled from 'styled-components'
-
 
 interface QueryLabelProps {
   label?: string;

--- a/frontend/components/views/QueryView/QueryView.tsx
+++ b/frontend/components/views/QueryView/QueryView.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../../types';
 import { defaultMargin } from '../../../style-variables';
 import { getPrettyTime } from '../../../lib/queries';
-import { once } from '../../../lib/utils';
+import { once, sendFeedback } from '../../../lib/utils';
 
 import QueryLabel from './QueryLabel';
 import QueryDb from './QueryDb';
@@ -71,7 +71,7 @@ const QueryView = ({
   useEffect(() => {
     const receiveDbs = (evt: IpcMainEvent, dbLists: unknown) => {
       if (isDbLists(dbLists)) {
-        setDatabases(dbLists.databaseList.map(db => db.db_name));
+        setDatabases(dbLists.databaseList.map((db) => db.db_name));
       }
     };
     ipcRenderer.on('db-lists', receiveDbs);
@@ -120,6 +120,9 @@ const QueryView = ({
   };
 
   const onRun = () => {
+    if (!localQuery.label.trim()) {
+      sendFeedback({type: 'info', message: 'Queries without a label will run but won\'t be saved'})
+    }
     // request backend to run query
     ipcRenderer.send('execute-query-tracked', {
       queryLabel: localQuery.label.trim(),
@@ -132,7 +135,10 @@ const QueryView = ({
   return (
     <>
       <TopRow>
-        <QueryLabel label={localQuery.label} onChange={onLabelChange} />
+        <QueryLabel
+          label={localQuery.label}
+          onChange={onLabelChange}
+        />
         <QueryDb
           db={localQuery.db}
           onChange={onDbChange}
@@ -143,7 +149,11 @@ const QueryView = ({
           totalTime={getPrettyTime(query)}
         />
       </TopRow>
-      <QuerySqlInput sql={localQuery?.sqlString ?? ''} onChange={onSqlChange} runQuery={onRun} />
+      <QuerySqlInput
+        sql={localQuery?.sqlString ?? ''}
+        onChange={onSqlChange}
+        runQuery={onRun}
+      />
       <CenterButton>
         <RunButton variant="contained" onClick={onRun}>
           Run Query


### PR DESCRIPTION
Allows users to run queries without a label and see their results, but doesn't save these queries to sidebar list of queries.