### PR TITLE
Removed the Generate Dummy Data Button on ER Tabling View

### DIFF
--- a/frontend/components/App.tsx
+++ b/frontend/components/App.tsx
@@ -51,6 +51,8 @@ const App = () => {
   const [selectedDb, setSelectedDb] = useState<AppState['selectedDb']>('');
   const [sidebarIsHidden, setSidebarHidden] = useState(false);
   const [newFilePath, setFilePath] = useState<AppState['newFilePath']>('');
+  const [ERView, setERView] = useState(true);
+
 
   /**
    * Hook to create new Query from data
@@ -125,7 +127,12 @@ const App = () => {
               queries={comparedQueries}
               show={shownView === 'compareView'}
             />
-            <DbView selectedDb={selectedDb} show={shownView === 'dbView'} />
+            <DbView 
+              selectedDb={selectedDb} 
+              show={shownView === 'dbView'}
+              setERView={setERView} 
+              ERView={ERView}
+            />
             <QueryView
               query={workingQuery}
               setQuery={setWorkingQuery}

--- a/frontend/components/views/DbView/DbView.tsx
+++ b/frontend/components/views/DbView/DbView.tsx
@@ -14,6 +14,8 @@ const requestDbListOnce = once(() => ipcRenderer.send('return-db-list'));
 interface DbViewProps {
   selectedDb: AppState['selectedDb'];
   show: boolean;
+  setERView: (boolean) => void;
+  ERView: boolean;
 }
 
 const StyledDummyButton = styled(Button)`
@@ -22,7 +24,7 @@ const StyledDummyButton = styled(Button)`
   right: ${sidebarShowButtonSize};
 `;
 
-const DbView = ({ selectedDb, show }: DbViewProps) => {
+const DbView = ({ selectedDb, show, setERView, ERView}: DbViewProps) => {
   const [dbTables, setTables] = useState<TableInfo[]>([]);
   const [selectedTable, setSelectedTable] = useState<TableInfo>();
   const [databases, setDatabases] = useState<DatabaseInfo[]>([]);
@@ -45,8 +47,6 @@ const DbView = ({ selectedDb, show }: DbViewProps) => {
     };
   });
 
-  
-
   const handleClickOpen = () => {
     setOpen(true);
   };
@@ -68,10 +68,11 @@ const DbView = ({ selectedDb, show }: DbViewProps) => {
         selectTable={(table: TableInfo) => setSelectedTable(table)}
         selectedTable={selectedTable}
         selectedDb={selectedDb}
+        setERView={setERView}
       />
       <br />
       <br />
-      {selectedTable ? (
+      {(selectedTable && !ERView) ? (
         <StyledDummyButton
           variant="contained"
           color="primary"

--- a/frontend/components/views/DbView/TablesTabBar.tsx
+++ b/frontend/components/views/DbView/TablesTabBar.tsx
@@ -41,6 +41,7 @@ interface TablesTabBarProps {
   selectTable: (table: TableInfo) => void;
   selectedTable: TableInfo | undefined;
   selectedDb: AppState['selectedDb'];
+  setERView?: (boolean) => void;
 }
 
 const StyledViewButton = styled(Button)`
@@ -48,11 +49,12 @@ const StyledViewButton = styled(Button)`
   margin-left: 0rem;
 `;
 
-const TablesTabs = ({
+const TablesTabs = ({ 
   tables,
   selectTable,
   selectedTable,
-  selectedDb
+  selectedDb,
+  setERView
 }: TablesTabBarProps) => {
   const handleChange = (event: React.ChangeEvent<{}>, newValue: number) => {
     selectTable(tables[newValue]);
@@ -107,14 +109,20 @@ const TablesTabs = ({
       <StyledViewButton
         variant="contained"
         color="primary"
-        onClick={() => SetView(true)}
+        onClick={() => {
+          SetView(true)
+          if(setERView) setERView(true)
+        }}
       >
         ER
       </StyledViewButton>
       <StyledViewButton
         variant="contained"
         color="primary"
-        onClick={() => SetView(false)}
+        onClick={() => {
+          SetView(false)
+          if(setERView) setERView(false)
+        }}
       >
         TABLE
       </StyledViewButton>


### PR DESCRIPTION
The generate Dummy Data Button now is only displayed when a user is on Tables View and not on ER Tabling