### PR TITLE
dummy data generator bug fixed - still need to test on SQL

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:8080",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/backend/DummyD/dummyDataMain.ts
+++ b/backend/DummyD/dummyDataMain.ts
@@ -29,6 +29,8 @@ const getRandomInt = (min: number, max: number) => {
 const generateDataByType = (columnObj: ColumnObj): string | number => {
   let length;
   // faker.js method to generate data by type
+  console.log('columnObj_datatype: ', columnObj.data_type)
+  
   switch (columnObj.data_type) {
     case 'smallint':
       return faker.random.number({ min: -32768, max: 32767 });

--- a/backend/channels.ts
+++ b/backend/channels.ts
@@ -9,6 +9,7 @@ import generateDummyData from './DummyD/dummyDataMain';
 import { ColumnObj, DBList, DummyRecords, DBType, LogType } from './BE_types';
 import backendObjToQuery from './ertable-functions';
 import logger from './Logging/masterlog';
+import { log } from 'console';
 
 const db = require('./models');
 const docConfig = require('./_documentsConfig');
@@ -452,11 +453,12 @@ ipcMain.handle( // generate dummy data
       message: '',
     };
     try {
-      console.log('data in generate-dummy-data', data);
+      console.log('data in generate-dummy-data', data); // gets here fine
       
       // Retrieves the Primary Keys and Foreign Keys for all the tables
-      const tableInfo: ColumnObj[] = await db.getTableInfo(data.tableName);
-
+      const tableInfo: ColumnObj[] = await db.getTableInfo(data.tableName, dbType); // maybe here?
+      console.log('tableInfo in generate-dummy-data', tableInfo); // working
+    
       // generate dummy data
       const dummyArray: DummyRecords = await generateDummyData(
         tableInfo,
@@ -487,6 +489,7 @@ ipcMain.handle( // generate dummy data
       };
     } catch (err: any) {
       // rollback transaction if there's an error in insertion and send back feedback to FE
+      console.log('err in generate-dummy-data', err)
       await db.query('Rollback;', null, dbType);
       feedback = {
         type: 'error',

--- a/backend/channels.ts
+++ b/backend/channels.ts
@@ -440,7 +440,7 @@ interface dummyDataRequestPayload {
   rows: number;
 }
 
-ipcMain.handle(
+ipcMain.handle( // generate dummy data
   'generate-dummy-data',
   async (event, data: dummyDataRequestPayload, dbType: DBType) => {
     logger("Received 'generate-dummy-data'", LogType.RECEIVE);

--- a/backend/channels.ts
+++ b/backend/channels.ts
@@ -452,6 +452,8 @@ ipcMain.handle( // generate dummy data
       message: '',
     };
     try {
+      console.log('data in generate-dummy-data', data);
+      
       // Retrieves the Primary Keys and Foreign Keys for all the tables
       const tableInfo: ColumnObj[] = await db.getTableInfo(data.tableName);
 

--- a/backend/channels.ts
+++ b/backend/channels.ts
@@ -496,8 +496,9 @@ ipcMain.handle( // generate dummy data
       };
     } finally {
       // send updated db info in case query affected table or database information
-      const dbsAndTables: DBList = await db.getLists();
-      event.sender.send('db-lists', dbsAndTables);
+      const dbsAndTables: DBList = await db.getLists(); // dummy data clear error is from here
+
+      event.sender.send('db-lists', dbsAndTables); // dummy data clear error is from here
 
       // send feedback back to FE
       event.sender.send('feedback', feedback);

--- a/backend/channels.ts
+++ b/backend/channels.ts
@@ -495,9 +495,10 @@ ipcMain.handle( // generate dummy data
         message: err,
       };
     } finally {
+      console.log('dbType inside generate-dummy-data', dbType)
       // send updated db info in case query affected table or database information
-      const dbsAndTables: DBList = await db.getLists(); // dummy data clear error is from here
-
+      const dbsAndTables: DBList = await db.getLists('', dbType); // dummy data clear error is from here
+      console.log('dbsAndTables in generate-dummy-data', dbsAndTables)
       event.sender.send('db-lists', dbsAndTables); // dummy data clear error is from here
 
       // send feedback back to FE
@@ -630,6 +631,7 @@ ipcMain.handle(
       };
     } finally {
       // send updated db info
+
       const updatedDb: DBList = await db.getLists(dbName, dbType);
       event.sender.send('db-lists', updatedDb);
 

--- a/backend/channels.ts
+++ b/backend/channels.ts
@@ -456,7 +456,7 @@ ipcMain.handle( // generate dummy data
       console.log('data in generate-dummy-data', data); // gets here fine
       
       // Retrieves the Primary Keys and Foreign Keys for all the tables
-      const tableInfo: ColumnObj[] = await db.getTableInfo(data.tableName, dbType); // maybe here?
+      const tableInfo: ColumnObj[] = await db.getTableInfo(data.tableName, dbType); // passed in dbType to second argument
       console.log('tableInfo in generate-dummy-data', tableInfo); // working
     
       // generate dummy data
@@ -489,7 +489,6 @@ ipcMain.handle( // generate dummy data
       };
     } catch (err: any) {
       // rollback transaction if there's an error in insertion and send back feedback to FE
-      console.log('err in generate-dummy-data', err)
       await db.query('Rollback;', null, dbType);
       feedback = {
         type: 'error',

--- a/backend/helperFunctions.ts
+++ b/backend/helperFunctions.ts
@@ -27,7 +27,7 @@ interface HelperFunctions {
 
 // PG = Postgres - Query necessary to run PG Query/Command
 // MYSQL = MySQL - Query necessary to run MySQL Query/Command
-const SQL_data = docConfig.getFullConfig();
+// const SQL_data = docConfig.getFullConfig();
 
 const helperFunctions: HelperFunctions = {
   // create a database

--- a/backend/models.ts
+++ b/backend/models.ts
@@ -43,7 +43,7 @@ const getColumnObjects = function (
     console.log('dbType - getColumnObjects: ', dbType);
         
 
-  if (dbType === DBType.Postgres) { // causing dbtype issues
+  if (dbType === DBType.Postgres) { 
     // query string to get constraints and table references as well
     queryString = `SELECT cols.column_name,
       cols.data_type,
@@ -476,7 +476,6 @@ const myObj: MyObj = {
         databaseList: [],
         tableList: [], // current database's tables
       };
-
       // Get initial postgres dbs
       getDBNames(DBType.Postgres)
         .then((pgdata) => {

--- a/backend/models.ts
+++ b/backend/models.ts
@@ -501,7 +501,8 @@ const myObj: MyObj = {
             })
             .finally(() => {
               if (dbType) {
-                getDBLists(dbType, dbName)
+                console.log('dbType is defined')
+                getDBLists(dbType, dbName) // dbLists returning empty array - DBType is not defined
                   .then((data) => {
                     logger(
                       `RESOLVING DB DETAILS: Fetched DB names along with Table List for DBType: ${dbType} and DB: ${dbName}`,
@@ -517,6 +518,7 @@ const myObj: MyObj = {
                     );
                   });
               } else {
+                console.log('dbType is not defined')
                 logger('RESOLVING DB DETAILS: Only DB Names', LogType.SUCCESS);
                 resolve(listObj);
               }

--- a/backend/models.ts
+++ b/backend/models.ts
@@ -35,13 +35,15 @@ let msql_pool;
 // and returns a promise that resolves to an array of columnObjects
 const getColumnObjects = function (
   tableName: string,
-  dbType: DBType
-): Promise<ColumnObj[]> {
-  let queryString;
+  dbType: DBType // error?
+  ): Promise<ColumnObj[]> {
+    let queryString;
+    
+    const value = [tableName];
+    console.log('dbType - getColumnObjects: ', dbType);
+        
 
-  const value = [tableName];
-
-  if (dbType === DBType.Postgres) {
+  if (dbType === DBType.Postgres) { // causing dbtype issues
     // query string to get constraints and table references as well
     queryString = `SELECT cols.column_name,
       cols.data_type,
@@ -219,6 +221,9 @@ const getDBLists = function (
     let query;
     const tableList: TableDetails[] = [];
     const promiseArray: Promise<ColumnObj[]>[] = [];
+
+    console.log('dbType - getDBLists: ', dbType);
+    
 
     if (dbType === DBType.Postgres) {
       query = `SELECT

--- a/frontend/components/App.tsx
+++ b/frontend/components/App.tsx
@@ -73,6 +73,7 @@ const App = () => {
   const [showConfigDialog, setConfigDialog] = useState(false);
 
   useEffect(() => {
+    console.log('dbTables:', dbTables, 'selectedTable: ', selectedTable, 'selectedDb: ', selectedDb, 'curDBType: ', curDBType, 'DBInfo: ', DBInfo, 'PG_isConnected: ', PG_isConnected, 'MYSQL_isConnected: ', MYSQL_isConnected);
     // Listen to backend for updates to list of available databases
     const dbListFromBackend = (evt: IpcRendererEvent, dbLists: DbLists) => {
       if (isDbLists(dbLists)) {

--- a/frontend/components/App.tsx
+++ b/frontend/components/App.tsx
@@ -82,9 +82,10 @@ const App = () => {
         setMYSQLStatus(dbLists.databaseConnected[1]);
 
         setSelectedTable(selectedTable? selectedTable : dbTables[0]);
+        
       }
     };
-    ipcRenderer.on('db-lists', dbListFromBackend);
+    ipcRenderer.on('db-lists', dbListFromBackend); // dummy data error here?
     requestDbListOnce();
     // return cleanup function
     return () => {
@@ -128,7 +129,6 @@ const App = () => {
       break;
     case 'newSchemaView': 
       shownView = 'newSchemaView';
-      break;
       break;
     case 'quickStartView':
     default:

--- a/frontend/components/modal/DummyDataModal.tsx
+++ b/frontend/components/modal/DummyDataModal.tsx
@@ -36,6 +36,9 @@ const DummyDataModal = ({
   const [isError, setIsError] = useState(false);
   const [isEmpty, setIsEmpty] = useState(true);
 
+  console.log('curDBType:', curDBType);
+
+
   const handleClose = () => {
     setIsError(false);
     setIsEmpty(true);
@@ -94,19 +97,19 @@ const DummyDataModal = ({
     };
 
     ipcRenderer
-      .invoke('generate-dummy-data', payload, curDBType)
-      .catch(() =>
-        sendFeedback({
-          type: 'error',
-          message: 'Failed to generate dummy data',
-        })
-      )
-      .catch((err: object) => {
-        console.log(err);
-      })
-      .finally(handleClose);
+    .invoke('generate-dummy-data', payload, curDBType)
+    .catch(() =>
+    sendFeedback({
+      type: 'error',
+      message: 'Failed to generate dummy data',
+    })
+    )
+    .catch((err: object) => {
+      console.log(err);
+    })
+    .finally(handleClose);
   };
-
+  
   return (
     <div>
       <Dialog

--- a/frontend/components/views/DbView/DbView.tsx
+++ b/frontend/components/views/DbView/DbView.tsx
@@ -36,7 +36,8 @@ const DbView = ({ selectedDb, show, setERView, ERView, curDBType, setDBType, DBI
   // const [databases, setDatabases] = useState<DatabaseInfo[]>([]);
 
   const [open, setOpen] = useState(false);
-
+  
+console.log('DB props', curDBType, selectedDb)
   
 
   const handleClickOpen = () => {


### PR DESCRIPTION
generate dummy data was causing issues with frontend display - cleared out display on click forcing user to click into another db and back

found out that dbType was not being passed in to db.getLists() (channels.ts ln 500) resulting in the returned value's tableList property being an empty array. App.tsx dbTables state was being set to dbLists.tableList which was an empty array.